### PR TITLE
Allow for using KClass<*> directly ➕  by forgery() delegate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Lint
         run: make lint
       - name: Unit Test
-        run: make unit-test
+        run: make test
       - name: Coverage
         run: make coverage
       - name: Report

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build clean coverage format lint publish unit-test
 
-all: clean format lint unit-test build
+all: clean format lint test build
 
 build:
 	./gradlew build
@@ -20,5 +20,5 @@ lint:
 publish:
 	./scripts/publish.sh ${GITHUB_RUN_NUMBER}
 
-unit-test:
+test:
 	./gradlew test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean coverage format lint publish unit-test
+.PHONY: all build clean coverage format lint publish test
 
 all: clean format lint test build
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ val testObject = forge.build(Employee::class)
 or by delegating
 
 ```kotlin
-val testObject: TestObject by forgery()
+val testObject: Employee by forgery()
 ```
 
 You can create different sized lists by specifying the number of elements.

--- a/README.md
+++ b/README.md
@@ -31,14 +31,26 @@ data class Employee(
 
 ```kotlin
 val forge = ModelForge()
-val testObject = forge.build(Employee::class.java)
+val testObject = forge.build(Employee::class)
+```
+
+or by delegating
+
+```kotlin
+val testObject: TestObject by forgery()
 ```
 
 You can create different sized lists by specifying the number of elements.
 
 ```kotlin
 val forge = ModelForge()
-val list = forge.buildList(TestObject::class.java, 3)
+val list = forge.buildList(TestObject::class, 3)
+```
+
+or by delegating
+
+```kotlin
+val testObjects: List<TestObject> by forgeries()
 ```
 
 ## Supported Types

--- a/src/main/kotlin/io/github/hellocuriosity/Forgery.kt
+++ b/src/main/kotlin/io/github/hellocuriosity/Forgery.kt
@@ -1,0 +1,9 @@
+package io.github.hellocuriosity
+
+public inline fun <reified T : Any> forgery(forger: ModelForge = ModelForge()): Lazy<T> = lazy {
+    forger.build(T::class)
+}
+
+public inline fun <reified T : Any> forgeries(forger: ModelForge = ModelForge(), size: Int = 10): Lazy<List<T>> = lazy {
+    forger.buildList(T::class, size)
+}

--- a/src/main/kotlin/io/github/hellocuriosity/ModelForge.kt
+++ b/src/main/kotlin/io/github/hellocuriosity/ModelForge.kt
@@ -14,7 +14,7 @@ import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import java.util.Date
 
-class ModelForge {
+open class ModelForge {
 
     /**
      * Creates an automatically generated model object
@@ -24,7 +24,7 @@ class ModelForge {
      *
      *  @return Instance of clazz
      */
-    fun <T> build(clazz: Class<T>): T {
+    open fun <T> build(clazz: Class<T>): T {
         val objenesis: Objenesis = ObjenesisStd()
         val instantiator: ObjectInstantiator<*> = objenesis.getInstantiatorOf(clazz)
         val model: T = instantiator.newInstance() as T
@@ -47,7 +47,7 @@ class ModelForge {
      *
      *  @return Instance of clazz
      */
-    fun <T> buildList(clazz: Class<T>, size: Int = 10): List<T> {
+    open fun <T> buildList(clazz: Class<T>, size: Int = 10): List<T> {
         val list = mutableListOf<T>()
         for (i in 0 until size) {
             list.add(i, build(clazz))

--- a/src/main/kotlin/io/github/hellocuriosity/ModelForgeKotlin.kt
+++ b/src/main/kotlin/io/github/hellocuriosity/ModelForgeKotlin.kt
@@ -1,0 +1,27 @@
+package io.github.hellocuriosity
+
+import kotlin.reflect.KClass
+
+/**
+ * Creates an automatically generated model object
+ *
+ *  @param <T> Type to instantiate
+ *  @param clazz Class to instantiate
+ *
+ *  @return Instance of clazz
+ */
+fun <T : Any> ModelForge.build(clazz: KClass<T>): T =
+    build(clazz.java)
+
+/**
+ *  Creates an automatically generated model list with
+ *  or without a specified size.
+ *
+ *  @param <T> Type to instantiate
+ *  @param clazz Class to instantiate
+ *  @param size Int number of models to create (defaulting to 10)
+ *
+ *  @return Instance of clazz
+ */
+fun <T : Any> ModelForge.buildList(clazz: KClass<T>, size: Int = 10): List<T> =
+    buildList(clazz.java, size)

--- a/src/test/kotlin/io/github/hellocuriosity/ForgeryTest.kt
+++ b/src/test/kotlin/io/github/hellocuriosity/ForgeryTest.kt
@@ -5,19 +5,16 @@ import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class ModelForgeTest {
-
-    private val forge = ModelForge()
-
+class ForgeryTest {
     @Test
-    fun testBuild() {
-        val testObject = forge.build(TestObject::class.java)
+    fun testForgery() {
+        val testObject: TestObject by forgery()
         testObject.assert()
     }
 
     @Test
-    fun testBuildList_Default() {
-        val list = forge.buildList(TestObject::class.java)
+    fun testForgeries_Default() {
+        val list: List<TestObject> by forgeries()
         assertEquals(10, list.size)
         list.map { testObject ->
             testObject.assert()
@@ -25,9 +22,9 @@ class ModelForgeTest {
     }
 
     @Test
-    fun testBuildList_WithSize() {
+    fun testForgeries_WithSize() {
         val size = 3
-        val list = forge.buildList(TestObject::class.java, size)
+        val list: List<TestObject> by forgeries(size = size)
         assertEquals(size, list.size)
         list.map { testObject ->
             testObject.assert()
@@ -35,12 +32,12 @@ class ModelForgeTest {
     }
 
     @Test(expected = ModelForgeException::class)
-    fun testBuild_WithUnsupportedType() {
+    fun testForgery_WithUnsupportedType() {
         data class UnsupportedTestObject(
             private val random: Random,
         )
 
-        val testObject = forge.build(UnsupportedTestObject::class.java)
+        val testObject: UnsupportedTestObject by forgery()
         assertNull(testObject)
     }
 }

--- a/src/test/kotlin/io/github/hellocuriosity/ModelForgeKotlinTest.kt
+++ b/src/test/kotlin/io/github/hellocuriosity/ModelForgeKotlinTest.kt
@@ -5,19 +5,19 @@ import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class ModelForgeTest {
+class ModelForgeKotlinTest {
 
     private val forge = ModelForge()
 
     @Test
     fun testBuild() {
-        val testObject = forge.build(TestObject::class.java)
+        val testObject = forge.build(TestObject::class)
         testObject.assert()
     }
 
     @Test
     fun testBuildList_Default() {
-        val list = forge.buildList(TestObject::class.java)
+        val list = forge.buildList(TestObject::class)
         assertEquals(10, list.size)
         list.map { testObject ->
             testObject.assert()
@@ -27,7 +27,7 @@ class ModelForgeTest {
     @Test
     fun testBuildList_WithSize() {
         val size = 3
-        val list = forge.buildList(TestObject::class.java, size)
+        val list = forge.buildList(TestObject::class, size)
         assertEquals(size, list.size)
         list.map { testObject ->
             testObject.assert()
@@ -40,7 +40,7 @@ class ModelForgeTest {
             private val random: Random,
         )
 
-        val testObject = forge.build(UnsupportedTestObject::class.java)
+        val testObject = forge.build(UnsupportedTestObject::class)
         assertNull(testObject)
     }
 }

--- a/src/test/kotlin/io/github/hellocuriosity/TestObject.kt
+++ b/src/test/kotlin/io/github/hellocuriosity/TestObject.kt
@@ -1,0 +1,26 @@
+package io.github.hellocuriosity
+
+import java.util.Date
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+data class TestObject(
+    val booleanValue: Boolean,
+    val dateValue: Date,
+    val doubleValue: Double,
+    val floatValue: Float,
+    val intValue: Int,
+    val longValue: Long,
+    val stringValue: String
+)
+
+fun TestObject.assert() {
+    assertNotNull(this.booleanValue)
+    assertNotNull(this.dateValue)
+    assertNotNull(this.doubleValue)
+    assertNotNull(this.floatValue)
+    assertNotNull(this.intValue)
+    assertNotNull(this.longValue)
+    assertNotNull(this.stringValue)
+    assertTrue(this.stringValue.isNotBlank())
+}


### PR DESCRIPTION
## Description

Allow using Kotlin class definitions directly.
Added forgery and forgeries property delegate.

## How to test / reproduce

See readme

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [x] Tests have been written
- [x] Appropriate labels have been applied - sure they have