### PR TITLE
[Fix] Exclude Companion Object Values

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,6 @@
 ## [0.6.0] - Not released yet
-Auto generation for additional types:
-* File
+* Exclude Companion Object Values
+* Support for File type.
 
 ## [0.5.1] - June 1st 2021
 * Support for optional variables.

--- a/src/main/kotlin/io/github/hellocuriosity/ModelForge.kt
+++ b/src/main/kotlin/io/github/hellocuriosity/ModelForge.kt
@@ -95,7 +95,7 @@ open class ModelForge {
      */
     private fun <T> Class<T>.eligibleFields(): Array<Field> =
         this.declaredFields
-            .filter { field -> !Modifier.isTransient(field.modifiers) }
+            .filter { field -> !Modifier.isTransient(field.modifiers) && !Modifier.isStatic(field.modifiers) }
             .toTypedArray()
 
     /**

--- a/src/test/kotlin/io/github/hellocuriosity/TestObject.kt
+++ b/src/test/kotlin/io/github/hellocuriosity/TestObject.kt
@@ -35,7 +35,11 @@ data class TestObject(
     val listOptional: List<ComplexObject>?,
     val complexObject: ComplexObject,
     val complexOptional: ComplexObject?
-)
+) {
+    companion object {
+        const val COMPANION_VALUE = 1234
+    }
+}
 
 enum class TestEnum {
     ONE, TWO, THREE


### PR DESCRIPTION
## Description

This excludes `Companion Object` values from auto generation and closes #79 

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [x] Tests have been written
- [x] Appropriate labels have been applied