### PR TITLE
[Small] Don't Use Reflection When Provider is Given

### DIFF
--- a/src/main/kotlin/io/github/hellocuriosity/ModelForge.kt
+++ b/src/main/kotlin/io/github/hellocuriosity/ModelForge.kt
@@ -36,13 +36,14 @@ open class ModelForge {
      *  @return Instance of clazz
      */
     open fun <T> build(clazz: Class<T>): T {
-        val objenesis: Objenesis = ObjenesisStd()
-        val instantiator: ObjectInstantiator<*> = objenesis.getInstantiatorOf(clazz)
-        val model: T = instantiator.newInstance() as T
 
         if (providers.isNotEmpty()) {
             providers[clazz]?.let { return it.get() as T }
         }
+
+        val objenesis: Objenesis = ObjenesisStd()
+        val instantiator: ObjectInstantiator<*> = objenesis.getInstantiatorOf(clazz)
+        val model: T = instantiator.newInstance() as T
 
         clazz.eligibleFields().map { field ->
             field.isAccessible = true


### PR DESCRIPTION
## Description

This moves the provider check to the top of the build method, to avoid instantiating objects for reflection without needing to do so. This may have been the cause of #86. Nonetheless, this is still a small improvement 🏕️ 

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [-] Tests have been written
- [x] Appropriate labels have been applied