### PR TITLE
[Fix] Build with Java 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v2.3.0
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '8'
           cache: 'gradle'
       - name: Lint
         run: make lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-java@v2.3.0
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '8'
           cache: 'gradle'
       - name: Publish
         run: |

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## [0.7.4] - September 16th 2021
+
+* Build with Java 8
+
 ## [0.7.3] - September 15th 2021
 
 * Add GitHub Action dependencies to dependabot

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Model Forge is a library to automate model generation for automated testing:
 
 ```kotlin
 dependencies {
-    testImplementation("io.github.hellocuriosity:model-forge:0.7.3")
+    testImplementation("io.github.hellocuriosity:model-forge:0.7.4")
 }
 ```
 
@@ -34,7 +34,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.hellocuriosity:model-forge:0.7.3'
+    testImplementation 'io.github.hellocuriosity:model-forge:0.7.4'
 }
 ```
 
@@ -53,7 +53,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation("io.github.hellocuriosity:model-forge:0.7.3.xx-SNAPSHOT")
+    testImplementation("io.github.hellocuriosity:model-forge:0.7.4.xx-SNAPSHOT")
 }
 ```
 
@@ -68,7 +68,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'io.github.hellocuriosity:model-forge:0.7.3.xx-SNAPSHOT'
+    testImplementation 'io.github.hellocuriosity:model-forge:0.7.4.xx-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
## Description

This builds with Java 8 instead of 11 to ensure support for older projects running java 8 such as Android.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [-] Tests have been written
- [x] Appropriate labels have been applied