### PR TITLE
[Enhancement] Kover Integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build clean coverage format lint local publish test
 
-all: clean format lint test build
+all: clean format lint test coverage build
 
 build:
 	./gradlew build
@@ -9,7 +9,7 @@ clean:
 	./gradlew clean
 
 coverage:
-	./gradlew jacocoTestReport
+	./gradlew koverXmlReport
 
 format:
 	./gradlew formatKotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+import kotlinx.kover.api.KoverTaskExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 allprojects {
@@ -13,7 +14,7 @@ plugins {
     // Quality gate
     id("org.jmailen.kotlinter") version "3.8.0"
     id("io.gitlab.arturbosch.detekt") version "1.19.0"
-    jacoco
+    id("org.jetbrains.kotlinx.kover") version "0.4.4"
 }
 
 repositories {
@@ -50,4 +51,16 @@ tasks.withType<Detekt>().configureEach {
 
 tasks.withType<DetektCreateBaselineTask>().configureEach {
     jvmTarget = "1.8"
+}
+
+tasks.test {
+    extensions.configure(KoverTaskExtension::class) {
+        isEnabled = true
+    }
+}
+
+kover {
+    isEnabled = true
+    jacocoEngineVersion.set("0.8.7")
+    generateReportOnCheck.set(true)
 }

--- a/forge-core/build.gradle.kts
+++ b/forge-core/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     // Quality gate
     id("org.jmailen.kotlinter")
     id("io.gitlab.arturbosch.detekt")
-    jacoco
 
     // Publishing
     `java-library`
@@ -27,16 +26,14 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
 }
 
-jacoco {
-    toolVersion = "0.8.7"
+tasks.koverXmlReport {
+    isEnabled = true
+    xmlReportFile.set(file("$buildDir/reports/kover/result.xml"))
 }
 
-tasks.jacocoTestReport {
-    reports {
-        csv.isEnabled = false
-        html.isEnabled = false
-        xml.isEnabled = true
-    }
+tasks.koverHtmlReport {
+    isEnabled = true
+    htmlReportDir.set(layout.buildDirectory.dir("$buildDir/reports/kover/html-result"))
 }
 
 tasks.register<Jar>("sourcesJar") {


### PR DESCRIPTION
## Description

This removes `jacoco` in favor of `kover` for generating coverage reports on kotlin code. This closes #121.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [-] Tests have been written
- [x] Appropriate labels have been applied