### PR TITLE
[Remove] Codecov Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,4 @@ jobs:
       - name: Coverage
         run: make coverage
       - name: Report
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          fail_ci_if_error: true
+        run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
## Description

Codecov Actions are quite buggy and fail way to often. This removes the action and just uses the bash uploader.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [-] Tests have been written
- [x] Appropriate labels have been applied