### PR TITLE
Fix StringProvider treatment of invalid wordCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,5 @@ If you contribute to Model Forge, please feel free to add yourself to the list!
     * Kotlin class definitions
     * Forgery and forgeries property delegate
     * Reified inline extension functions
+* [Alicja Kozikowska](https://github.com/Ashlett) - Contributor
+    * Fix StringProvider treatment of invalid wordCount

--- a/forge-core/src/main/kotlin/io/github/hellocuriosity/providers/StringProvider.kt
+++ b/forge-core/src/main/kotlin/io/github/hellocuriosity/providers/StringProvider.kt
@@ -1,6 +1,7 @@
 package io.github.hellocuriosity.providers
 
 import com.thedeanda.lorem.LoremIpsum
+import io.github.hellocuriosity.ModelForgeException
 
 /**
  * Auto generates a String
@@ -20,9 +21,8 @@ class StringProvider(
     }
 
     override fun get(): String {
-        if (wordCount <= 0) {
-            println("$wordCount is not a valid input, reverting to default $DEFAULT_VALUE")
-            return lorem.getWords(wordCount)
+        if (wordCount < 0) {
+            throw ModelForgeException("$wordCount is not a valid word count")
         }
         return lorem.getWords(wordCount)
     }

--- a/forge-core/src/main/kotlin/io/github/hellocuriosity/providers/StringProvider.kt
+++ b/forge-core/src/main/kotlin/io/github/hellocuriosity/providers/StringProvider.kt
@@ -21,9 +21,10 @@ class StringProvider(
     }
 
     override fun get(): String {
-        if (wordCount < 0) {
-            throw ModelForgeException("$wordCount is not a valid word count")
+        return when {
+            wordCount < 0 -> throw ModelForgeException("Cannot generate string of $wordCount words")
+            wordCount == 0 -> ""
+            else -> lorem.getWords(wordCount)
         }
-        return lorem.getWords(wordCount)
     }
 }

--- a/forge-core/src/test/kotlin/io/github/hellocuriosity/providers/StringProviderTest.kt
+++ b/forge-core/src/test/kotlin/io/github/hellocuriosity/providers/StringProviderTest.kt
@@ -1,5 +1,6 @@
 package io.github.hellocuriosity.providers
 
+import io.github.hellocuriosity.ModelForgeException
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 
@@ -14,11 +15,14 @@ class StringProviderTest {
     }
 
     @Test
-    fun testGetZeroOrLess() {
-        for (i in -1000..0) {
-            val words = StringProvider(wordCount = i).get()
-            assertEquals(1, words.count())
-        }
+    fun testGetZero() {
+        val emptyString = StringProvider(wordCount = 0).get()
+        assertEquals("", emptyString)
+    }
+
+    @Test(expected = ModelForgeException::class)
+    fun testGetLessThanZero() {
+        StringProvider(wordCount = -1).get()
     }
 
     private fun String.count(): Int =


### PR DESCRIPTION
## Description

Fixes https://github.com/HelloCuriosity/model-forge/issues/151 as described in the **Proposal** section.

## How to test / reproduce

Automated tests should suffice.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [x] Tests have been written
- [x] Appropriate labels have been applied