### PR TITLE
[Enhancement] Better Output Message in attempt

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,7 @@
 ## [0.9.0] - Not released yet
 
 * Support for map collection type
+* Better output message when using `attempt`
 
 ## [0.8.0] - December 7th 2021
 

--- a/forge-core/src/main/kotlin/io/github/hellocuriosity/TryExt.kt
+++ b/forge-core/src/main/kotlin/io/github/hellocuriosity/TryExt.kt
@@ -1,9 +1,9 @@
 package io.github.hellocuriosity
 
 @Suppress("SwallowedException")
-fun <T> Any.attempt(block: () -> T) = try {
+fun <T> attempt(block: () -> T) = try {
     block()
 } catch (e: InstantiationError) {
     // Throw model forge exception instead
-    throw ModelForgeException("$this is not yet supported")
+    throw ModelForgeException("${e.message} is not yet supported")
 }


### PR DESCRIPTION
## Description
This makes the `ModelForgeException` message while using `attempt` easier to read, in order to better track down issues and or assist users of the library. 

## How to test / reproduce

Generate a model with a random type. The new output reads:

```
io.github.hellocuriosity.ModelForgeException: kotlin.random.Random is not yet supported
```

as opposed to the current cryptic output:

```
io.github.hellocuriosity.ModelForgeException:
io.github.hellocuriosity.ModelForge@1cf56f0f is not yet supported
``` 

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Description contains clear instructions on how to test the feature (where applicable)
- [ ] Tests have been written
- [x] Appropriate labels have been applied