### PR TITLE
[Enhancement] Dependency Checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean coverage format lint local publish test
+.PHONY: all build clean dependencies coverage format lint local publish test
 
 all: clean format lint test coverage build
 
@@ -10,6 +10,9 @@ clean:
 
 coverage:
 	./gradlew koverXmlReport
+
+dependencies:
+	./gradlew dependencyUpdates
 
 format:
 	./gradlew formatKotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import kotlinx.kover.api.KoverTaskExtension
@@ -12,9 +13,10 @@ plugins {
     kotlin("jvm") version Versions.kotlin
 
     // Quality gate
-    id("org.jmailen.kotlinter") version Versions.kotlinter
-    id("io.gitlab.arturbosch.detekt") version Versions.detekt
-    id("org.jetbrains.kotlinx.kover") version Versions.kover
+    id(Dependency.kotlinter) version Versions.kotlinter
+    id(Dependency.detekt) version Versions.detekt
+    id(Dependency.kover) version Versions.kover
+    id(Dependency.versions) version Versions.versions
 }
 
 repositories {
@@ -57,4 +59,18 @@ kover {
     isDisabled = false
     jacocoEngineVersion.set("0.8.7")
     generateReportOnCheck = true
+}
+
+fun isNonStable(version: String): Boolean {
+    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
+    val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+    val isStable = stableKeyword || regex.matches(version)
+    return isStable.not()
+}
+
+tasks.withType<DependencyUpdatesTask> {
+    rejectVersionIf {
+        isNonStable(candidate.version)
+    }
+    outputFormatter = "html"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,6 +8,7 @@ object Versions {
     const val kotlinter = "3.9.0"
     const val detekt = "1.19.0"
     const val kover = "0.5.0"
+    const val versions = "0.42.0"
 }
 
 object Dependency {
@@ -22,4 +23,10 @@ object Dependency {
         const val junitJupiter = "org.junit.jupiter:junit-jupiter:${Versions.jupiter}"
         const val mockK = "io.mockk:mockk:${Versions.mockk}"
     }
+
+    // Quality Gates
+    const val detekt = "io.gitlab.arturbosch.detekt"
+    const val kotlinter = "org.jmailen.kotlinter"
+    const val kover = "org.jetbrains.kotlinx.kover"
+    const val versions = "com.github.ben-manes.versions"
 }

--- a/forge-core/build.gradle.kts
+++ b/forge-core/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
     kotlin("jvm")
 
     // Quality gate
-    id("org.jmailen.kotlinter")
-    id("io.gitlab.arturbosch.detekt")
+    id(Dependency.kotlinter)
+    id(Dependency.detekt)
 
     // Publishing
     `java-library`


### PR DESCRIPTION
## Description

This adds a dependency checker in order to easily check which dependencies are out dated. This is important since dependabot doesn't support versioning via the `buildSrc`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Description contains clear instructions on how to test the feature (where applicable)
- [ ] Tests have been written
- [x] Appropriate labels have been applied