### PR TITLE
[CI/CD] Auto Publishing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,36 @@
+name: Release ✈️
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  cancel-previous:
+    name: Cancel Publishing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Build
+        uses: styfle/cancel-workflow-action@0.10.0
+        with:
+          access_token: ${{ github.token }}
+
+  create-release:
+    if: ${{ contains(github.event.*.labels.*.name, 'release :tada:') }}
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: cancel-previous
+    env:
+      GITHUB_TOKEN: ${{ secrets.AUTO_RELEASE_PAT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Major Version Bump
+        if: ${{ contains(github.event.*.labels.*.name, 'major :1st_place_medal:') }}
+        run: make version BUMP=major
+      - name: Minor Version Bump
+        if: ${{ contains(github.event.*.labels.*.name, 'minor :2nd_place_medal:') }}
+        run: make version BUMP=minor
+      - name: Patch Version Bump
+        if: ${{ contains(github.event.*.labels.*.name, 'patch :3rd_place_medal:') }}
+        run: make version BUMP=patch

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean dependencies coverage format lint local publish test
+.PHONY: all build clean dependencies coverage format lint local publish test version
 
 all: clean format lint test coverage build
 
@@ -28,3 +28,7 @@ publish:
 
 test:
 	./gradlew test
+
+version:
+	./scripts/bump-version.sh
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+BUMP ?= empty
+
 .PHONY: all build clean dependencies coverage format lint local publish test version
 
 all: clean format lint test coverage build
@@ -30,5 +32,4 @@ test:
 	./gradlew test
 
 version:
-	./scripts/bump-version.sh
-
+	./scripts/bump-version.sh ${BUMP}

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+#
+git fetch --force --tags
+CURRENT_RELEASE=$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>&1)
+
+# Separate major, minor and patch numbers
+IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT_RELEASE"
+
+RELEASE_TYPE="patch"
+
+# $/${} is unnecessary on arithmetic variables.
+# shellcheck disable=SC2004
+if [[ "${RELEASE_TYPE}" == "major" ]]; then
+  NEW_RELEASE="$(($MAJOR + 1)).$MINOR.$PATCH"
+elif [ "${RELEASE_TYPE}" == "minor" ]; then
+  NEW_RELEASE="$MAJOR.$(($MINOR + 1)).$PATCH"
+else
+  NEW_RELEASE="$MAJOR.$MINOR.$(($PATCH + 1))"
+fi
+
+echo "Bumping version from $CURRENT_RELEASE to $NEW_RELEASE"
+
+gh release create "$NEW_RELEASE" --target "main" --generate-notes

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,21 +2,21 @@
 
 set -o pipefail
 
-#
+RELEASE_TYPE=${1}
+
+# Get current release version
 git fetch --force --tags
-CURRENT_RELEASE=$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>&1)
+CURRENT_RELEASE=$(git tag --sort=committerdate | tail -1)
 
 # Separate major, minor and patch numbers
 IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT_RELEASE"
 
-RELEASE_TYPE="patch"
-
 # $/${} is unnecessary on arithmetic variables.
 # shellcheck disable=SC2004
 if [[ "${RELEASE_TYPE}" == "major" ]]; then
-  NEW_RELEASE="$(($MAJOR + 1)).$MINOR.$PATCH"
+  NEW_RELEASE="$(($MAJOR + 1)).0.0"
 elif [ "${RELEASE_TYPE}" == "minor" ]; then
-  NEW_RELEASE="$MAJOR.$(($MINOR + 1)).$PATCH"
+  NEW_RELEASE="$MAJOR.$(($MINOR + 1)).0"
 else
   NEW_RELEASE="$MAJOR.$MINOR.$(($PATCH + 1))"
 fi

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -8,7 +8,7 @@ REPO_DIR="$(cd "$(dirname "$0")/../" && pwd)"
 
 # Create Version
 git fetch --force --tags
-TAG=$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>&1)
+TAG=$(git tag --sort=committerdate | tail -1)
 
 if [[ "${IS_RELEASE}" == "true" ]]; then
   export VERSION="$TAG"


### PR DESCRIPTION
## Description

This will automatically create a release including release notes if the label set to `release 🎉 `. In order to bump the version set either `major 🥇`, `minor 🥈` or `patch 🥉` to automatically bump the version accordingly.

This closes #185 

## Example
If the current version is `0.9.0` then:
* `major 🥇` -> `1.0.0`
* `minor 🥈` -> `0.10.0`
* `patch 🥉` -> `0.9.1`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [ ] Tests have been written
- [x] Appropriate labels have been applied
