### PR TITLE
[Housekeeping] Remove Gradle Eco System From Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: gradle
-    directory: "/"
-    schedule:
-      interval: daily
-      time: "08:00"
-      timezone: Europe/Berlin
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -18,4 +8,4 @@ updates:
       timezone: Europe/Berlin
     open-pull-requests-limit: 10
     labels:
-      - GitHub Actions
+      - dependencies


### PR DESCRIPTION
## Description

This removes gradle from the dependabot configuration and reduces the extra noise (#199)

This fixes #200 and closes #199

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [ ] Tests have been written
- [x] Appropriate labels have been applied
