### PR TITLE
[Housekeeping] Enable Coverage Reporting on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,13 +10,13 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 5%
+        target: 89
+        threshold: 1%
         only_pulls: true
 
     patch:
       default:
-        target: auto
+        target: 100
         threshold: 5%
         only_pulls: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,10 +46,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: cancel-previous
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: "Generate Coverage Report"
         run: make coverage
       - name: "Upload Coverage Report"
         uses: codecov/codecov-action@v3.1.1
         with:
           files: ./build/reports/kover/result.xml
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,12 +40,6 @@ jobs:
         run: make lint
       - name: Test
         run: make test
-      - name: Coverage
-        run: make coverage
-      - name: Report
-        uses: codecov/codecov-action@v3.1.1
-        with:
-          files: ./build/reports/kover/result.xml
 
   report:
     name: "Report"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,4 +43,6 @@ jobs:
       - name: Coverage
         run: make coverage
       - name: Report
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          files: ./build/reports/kover/result.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,3 +46,16 @@ jobs:
         uses: codecov/codecov-action@v3.1.1
         with:
           files: ./build/reports/kover/result.xml
+
+  report:
+    name: "Report"
+    runs-on: ubuntu-latest
+    needs: cancel-previous
+    steps:
+      - name: "Generate Coverage Report"
+        run: make coverage
+      - name: "Upload Coverage Report"
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          files: ./build/reports/kover/result.xml
+

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:
 	./gradlew clean
 
 coverage:
-	./gradlew koverXmlReport
+	./gradlew koverMergedReport
 
 dependencies:
 	./gradlew dependencyUpdates

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,13 +61,6 @@ kover {
     generateReportOnCheck = true
 }
 
-fun isNonStable(version: String): Boolean {
-    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
-    val regex = "^[0-9,.v-]+(-r)?$".toRegex()
-    val isStable = stableKeyword || regex.matches(version)
-    return isStable.not()
-}
-
 tasks.withType<DependencyUpdatesTask> {
     rejectVersionIf {
         isNonStable(candidate.version)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,29 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import kotlinx.kover.api.KoverTaskExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 allprojects {
     group = "io.github.hellocuriosity"
     version = System.getenv("VERSION") ?: "local"
+
+    apply(plugin = "kover")
+
+    extensions.configure<kotlinx.kover.api.KoverProjectConfig> {
+        isDisabled.set(false)
+        engine.set(kotlinx.kover.api.JacocoEngine("0.8.8"))
+    }
+
+    koverMerged {
+        xmlReport {
+            onCheck.set(false)
+            reportFile.set(layout.buildDirectory.file("$buildDir/reports/kover/result.xml"))
+        }
+        htmlReport {
+            onCheck.set(false)
+            reportDir.set(layout.buildDirectory.dir("$buildDir/reports/kover/html-result"))
+        }
+    }
 }
 
 plugins {
@@ -49,16 +66,8 @@ tasks.withType<DetektCreateBaselineTask>().configureEach {
     jvmTarget = "11"
 }
 
-tasks.test {
-    extensions.configure(KoverTaskExtension::class) {
-        isEnabled = true
-    }
-}
-
-kover {
-    isDisabled = false
-    jacocoEngineVersion.set("0.8.7")
-    generateReportOnCheck = true
+koverMerged {
+    enable()
 }
 
 tasks.withType<DependencyUpdatesTask> {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object Versions {
     const val kotlin = "1.7.10"
     const val kotlinter = "3.11.1"
     const val detekt = "1.20.0"
-    const val kover = "0.6.0"
+    const val kover = "0.6.1"
     const val versions = "0.42.0"
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object Versions {
     const val kotlin = "1.7.10"
     const val kotlinter = "3.11.1"
     const val detekt = "1.20.0"
-    const val kover = "0.5.1"
+    const val kover = "0.6.0"
     const val versions = "0.42.0"
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -30,3 +30,10 @@ object Dependency {
     const val kover = "org.jetbrains.kotlinx.kover"
     const val versions = "com.github.ben-manes.versions"
 }
+
+fun isNonStable(version: String): Boolean {
+    val stableKeyword = setOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
+    val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+    val isStable = stableKeyword || regex.matches(version)
+    return isStable.not()
+}

--- a/forge-core/build.gradle.kts
+++ b/forge-core/build.gradle.kts
@@ -33,16 +33,6 @@ java {
     withJavadocJar()
 }
 
-tasks.koverXmlReport {
-    isEnabled = true
-    xmlReportFile.set(file("$buildDir/reports/kover/result.xml"))
-}
-
-tasks.koverHtmlReport {
-    isEnabled = true
-    htmlReportDir.set(layout.buildDirectory.dir("$buildDir/reports/kover/html-result"))
-}
-
 tasks.withType<Sign>().configureEach {
     onlyIf { System.getenv("CI") == "true" }
 }


### PR DESCRIPTION
## Description

This enables coverage reports on PRs and bumps the kover version from `0.5.1` to `0.6.0`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [ ] Tests have been written
- [x] Appropriate labels have been applied
