### PR TITLE
[Dependency] Bump Kotlinter to 3.13.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,7 +5,7 @@ object Versions {
     const val jupiter = "5.9.1"
     const val mockk = "1.13.2"
     const val kotlin = "1.7.20"
-    const val kotlinter = "3.12.0"
+    const val kotlinter = "3.13.0"
     const val detekt = "1.22.0"
     const val kover = "0.6.1"
     const val versions = "0.44.0"


### PR DESCRIPTION
## Description

This bumps Kotlinter to version `3.13.0`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [ ] Tests have been written
- [x] Appropriate labels have been applied
