### PR TITLE
[Dependency] Bump Kotlin to 1.8.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     const val lorem = "2.1"
     const val jupiter = "5.9.2"
     const val mockk = "1.13.4"
-    const val kotlin = "1.7.20"
+    const val kotlin = "1.8.0"
     const val kotlinter = "3.13.0"
     const val detekt = "1.22.0"
     const val kover = "0.6.1"


### PR DESCRIPTION
## Description

This bumps Kotlin to version `1.8.0`

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [ ] Tests have been written
- [x] Appropriate labels have been applied
