### PR TITLE
[Housekeeping] Detekt Should Target JVM 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ tasks.test {
 }
 
 tasks.withType<Detekt>().configureEach {
-    jvmTarget = "11"
+    jvmTarget = "17"
     reports {
         html.required.set(true)
         xml.required.set(false)
@@ -63,7 +63,7 @@ tasks.withType<Detekt>().configureEach {
 }
 
 tasks.withType<DetektCreateBaselineTask>().configureEach {
-    jvmTarget = "11"
+    jvmTarget = "17"
 }
 
 koverMerged {


### PR DESCRIPTION
## Description

This cleans up the build.gradle a bit and makes sure that detekt also targets JVM version 17

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [ ] Tests have been written
- [x] Appropriate labels have been applied
