### PR TITLE
[Documentation] Correct Spelling Mistakes

### DIFF
--- a/website/docs/supported-types/boolean.md
+++ b/website/docs/supported-types/boolean.md
@@ -6,5 +6,5 @@ sidebar_position: 1
 
 The `boolean` provider generates a random boolean value.
 
-### Default Behavoir
+### Default Behavior
 `true` or `false`

--- a/website/docs/supported-types/byte.md
+++ b/website/docs/supported-types/byte.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 The `byte` provider generates a random byte value between two integers.
 
-### Default Behavoir
+### Default Behavior
 Between `-128` and `127`
 
 ### Extending the Provider

--- a/website/docs/supported-types/calendar.md
+++ b/website/docs/supported-types/calendar.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 The `calendar` provider generates a random calendar instance between two `timestamps`.
 
-### Default Behavoir
+### Default Behavior
 From `529714800000L` until `1617141600000L`
 
 ### Extending the Provider

--- a/website/docs/supported-types/char.md
+++ b/website/docs/supported-types/char.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 The `char` provider generates a random character from a list of chars.
 
-### Default Behavoir
+### Default Behavior
 
 From `('a'..'z') + ('A'..'Z') + ('0'..'9')`
 

--- a/website/docs/supported-types/date.md
+++ b/website/docs/supported-types/date.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 The `date` provider generates a random calendar instance between two `timestamps`.
 
-### Default Behavoir
+### Default Behavior
 From `529714800000L` until `1617141600000L`
 
 ### Extending the Provider

--- a/website/docs/supported-types/double.md
+++ b/website/docs/supported-types/double.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 The `double` provider generates a random double value between two doubles.
 
-### Default Behavoir
+### Default Behavior
 
 Between `4.9E-324` and `1.7976931348623157E308`
 

--- a/website/docs/supported-types/file.md
+++ b/website/docs/supported-types/file.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 The `file` provider generates a file with a random name from the `StringProvider`.
 
-### Default Behavoir
+### Default Behavior
 
 See [string](string.md).
 

--- a/website/docs/supported-types/float.md
+++ b/website/docs/supported-types/float.md
@@ -6,7 +6,7 @@ sidebar_position: 9
 
 The `float` provider generates a random float value between two doubles.
 
-### Default Behavoir
+### Default Behavior
 
 Between `1.4E-45F` and `3.4028235E38F`
 

--- a/website/docs/supported-types/instant.md
+++ b/website/docs/supported-types/instant.md
@@ -6,7 +6,7 @@ sidebar_position: 11
 
 The `instant` provider generates a random instant between two `timestamps`.
 
-### Default Behavoir
+### Default Behavior
 From `529714800000L` until `1617141600000L`
 
 ### Extending the Provider

--- a/website/docs/supported-types/int.md
+++ b/website/docs/supported-types/int.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 The `int` provider generates a random int value between two integers.
 
-### Default Behavoir
+### Default Behavior
 Between `-2147483648` and `2147483647`
 
 ### Extending the Provider

--- a/website/docs/supported-types/long.md
+++ b/website/docs/supported-types/long.md
@@ -6,7 +6,7 @@ sidebar_position: 12
 
 The `long` provider generates a random long value between two longs.
 
-### Default Behavoir
+### Default Behavior
 Between `-9223372036854775807L - 1L` and `9223372036854775807L`
 
 ### Extending the Provider

--- a/website/docs/supported-types/short.md
+++ b/website/docs/supported-types/short.md
@@ -6,7 +6,7 @@ sidebar_position: 13
 
 The `short` provider generates a random short value between two integers.
 
-### Default Behavoir
+### Default Behavior
 Between `-32768` and `32767`
 
 ### Extending the Provider

--- a/website/docs/supported-types/string.md
+++ b/website/docs/supported-types/string.md
@@ -6,7 +6,7 @@ sidebar_position: 14
 
 The `string` provider generate a random string.
 
-### Default Behavoir
+### Default Behavior
 
 `1` word
 

--- a/website/docs/supported-types/ubyte.md
+++ b/website/docs/supported-types/ubyte.md
@@ -6,7 +6,7 @@ sidebar_position: 15
 
 The `UByte` provider generates a random UByte value between two unsigned integers.
 
-### Default Behavoir
+### Default Behavior
 
 Between `0` and `255`
 

--- a/website/docs/supported-types/uint.md
+++ b/website/docs/supported-types/uint.md
@@ -6,7 +6,7 @@ sidebar_position: 16
 
 The `UInt` provider generates a random UInt value between two unsigned integers.
 
-### Default Behavoir
+### Default Behavior
 
 Between <code>0</code> and <code>4,294,967,295 (2<sup>32 - 1</sup>)</code>
 

--- a/website/docs/supported-types/ulong.md
+++ b/website/docs/supported-types/ulong.md
@@ -6,7 +6,7 @@ sidebar_position: 17
 
 The `ULong` provider generates a random ULong value between two unsigned longs.
 
-### Default Behavoir
+### Default Behavior
 
 Between <code>0</code> and <code>18,446,744,073,709,551,615 (2<sup>64 - 1</sup>)</code>
 


### PR DESCRIPTION
## Description

Through the copy and pasting of documentation, `behavior` was continually spelled wrong. This fixes that spelling issue.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [-] Description contains clear instructions on how to test the feature (where applicable)
- [-] Tests have been written
- [x] Appropriate labels have been applied
- [-] Update [README](../README.md) (where applicable)
- [x] Update [Documentation](../website/docs/introduction.md) (where applicable)
