### PR TITLE
[Housekeeping] Enable Kotlin Toolchain for Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Model Forge is a library to automate model generation for automated testing:
 
 ```kotlin
 dependencies {
-    testImplementation("io.github.hellocuriosity:model-forge:1.5.0")
+    testImplementation("io.github.hellocuriosity:model-forge:1.5.1")
 }
 ```
 
@@ -36,7 +36,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.hellocuriosity:model-forge:1.5.0'
+    testImplementation 'io.github.hellocuriosity:model-forge:1.5.1'
 }
 ```
 
@@ -55,7 +55,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation("io.github.hellocuriosity:model-forge:1.5.0.xx-SNAPSHOT")
+    testImplementation("io.github.hellocuriosity:model-forge:1.5.1.xx-SNAPSHOT")
 }
 ```
 
@@ -70,7 +70,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'io.github.hellocuriosity:model-forge:1.5.0.xx-SNAPSHOT'
+    testImplementation 'io.github.hellocuriosity:model-forge:1.5.1.xx-SNAPSHOT'
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,12 @@ allprojects {
     group = "io.github.hellocuriosity"
     version = System.getenv("VERSION") ?: "local"
 
+    apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jetbrains.kotlinx.kover")
+
+    kotlin {
+        jvmToolchain(17)
+    }
 }
 
 plugins {

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -4,6 +4,10 @@ sidebar_position: 4
 
 # Changelog
 
+## [1.5.1] - December 5th 2024
+
+* Re-enable support for java 17
+
 ## [1.5.0] - October 31st 2024
 
 * Auto generation for additional types:

--- a/website/docs/getting-started/gradle-dependency.md
+++ b/website/docs/getting-started/gradle-dependency.md
@@ -8,7 +8,7 @@ Add the dependency to your `build.gradle` file to get started:
 
 ```kotlin
 dependencies {
-    testImplementation("io.github.hellocuriosity:model-forge:1.5.0")
+    testImplementation("io.github.hellocuriosity:model-forge:1.5.1")
 }
 ```
 
@@ -22,6 +22,6 @@ repositories {
 }
 
 dependencies {
-    testImplementation("io.github.hellocuriosity:model-forge:1.5.0.xx-SNAPSHOT")
+    testImplementation("io.github.hellocuriosity:model-forge:1.5.1.xx-SNAPSHOT")
 }
 ```


### PR DESCRIPTION
## Description

This sets the Kotlin (JVM) toolchain to support version 17.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Description contains clear instructions on how to test the feature (where applicable)
- [ ] Tests have been written
- [x] Appropriate labels have been applied
- [x] Update [README](../README.md) (where applicable)
- [x] Update [Documentation](../website/docs/introduction.md) (where applicable)
