### PR TITLE
fix: add Kotlin JVM plugin to version catalog so Renovate can track it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ allprojects {
 }
 
 plugins {
-    kotlin("jvm") version libs.versions.kotlin.get()
+    alias(libs.plugins.kotlin.jvm)
 
     // Quality gate
     alias(libs.plugins.kotlinter)

--- a/gradle/dependencies.versions.toml
+++ b/gradle/dependencies.versions.toml
@@ -21,6 +21,7 @@ junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jupi
 mockK = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }


### PR DESCRIPTION
## Summary

- Added `kotlin-jvm` plugin entry under `[plugins]` in `gradle/dependencies.versions.toml`
- Switched `build.gradle.kts` to use `alias(libs.plugins.kotlin.jvm)` instead of `kotlin("jvm") version libs.versions.kotlin.get()`

The Kotlin version was only declared under `[versions]` with no corresponding `[plugins]` entry, so Renovate had no package identifier (plugin ID) to look up on the Gradle Plugin Portal. This meant Renovate could not detect or create PRs for Kotlin version updates, leading to version mismatches when transitive dependencies (e.g. mockk) upgraded their Kotlin stdlib dependency beyond what the project's compiler supports.