### PR TITLE
chore: auto merge renovate dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,15 @@
   ],
   "labels": [
     "dependencies"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "digest",
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `packageRules` to `renovate.json` to enable automerge for `digest`, `minor`, and `patch` dependency updates